### PR TITLE
ci: changed to $GITHUB_OUTPUT from set-output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Set PROJECT_NAME
         id: vars
         run: |
-          echo "::set-output name=PROJECT_NAME::`TOP=$(git rev-parse --show-toplevel); echo ${TOP##*/}`"
+          echo "PROJECT_NAME=`TOP=$(git rev-parse --show-toplevel); echo ${TOP##*/}`" >> $GITHUB_OUTPUT
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/